### PR TITLE
fix(plugins): backfill missing dependencies for audited plugin installs

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -253,6 +253,28 @@ export interface InstallResult {
   enabled: boolean;
 }
 
+const PLUGIN_DEPENDENCY_BACKFILL: Record<string, readonly string[]> = {
+  "wopr-plugin-slack": ["@slack/bolt", "winston"],
+  "wopr-plugin-signal": ["winston"],
+  "wopr-plugin-whatsapp": ["@whiskeysockets/baileys", "pino", "qrcode-terminal", "winston"],
+  "wopr-plugin-imessage": ["winston"],
+  "wopr-plugin-webui": ["@kobalte/core", "solid-js"],
+  "wopr-plugin-p2p": ["discord.js", "hyperswarm", "winston"],
+  "wopr-plugin-provider-anthropic": ["@anthropic-ai/claude-agent-sdk", "@anthropic-ai/claude-code", "winston"],
+  "wopr-plugin-provider-kimi": ["@moonshot-ai/kimi-agent-sdk", "winston"],
+};
+
+function ensurePluginDependencies(pluginRoot: string, pluginName?: string): void {
+  if (!pluginName) return;
+
+  const requiredDeps = PLUGIN_DEPENDENCY_BACKFILL[pluginName];
+  if (!requiredDeps?.length) return;
+
+  logger.info(`[plugins] Backfilling missing dependencies for ${pluginName}...`);
+  const depArgs = requiredDeps.map(dep => `"${dep}"`).join(" ");
+  execSync(`npm install ${depArgs}`, { cwd: pluginRoot, stdio: "inherit" });
+}
+
 export async function installPlugin(source: string): Promise<InstalledPlugin> {
   mkdirSync(PLUGINS_DIR, { recursive: true });
 
@@ -279,6 +301,8 @@ export async function installPlugin(source: string): Promise<InstalledPlugin> {
     if (existsSync(pkgPath)) {
       logger.info(`[plugins] Installing dependencies for ${repo}...`);
       execSync("npm install", { cwd: pluginDir, stdio: "inherit" });
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+      ensurePluginDependencies(pluginDir, pkg.name);
       
       // Build TypeScript plugins if tsconfig.json exists
       if (existsSync(join(pluginDir, "tsconfig.json"))) {
@@ -317,6 +341,8 @@ export async function installPlugin(source: string): Promise<InstalledPlugin> {
     if (existsSync(pkgPath)) {
       logger.info(`[plugins] Installing dependencies for local plugin...`);
       execSync("npm install", { cwd: pluginDir, stdio: "inherit" });
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+      ensurePluginDependencies(pluginDir, pkg.name);
       
       // Build TypeScript plugins if tsconfig.json exists
       if (existsSync(join(pluginDir, "tsconfig.json"))) {
@@ -350,6 +376,7 @@ export async function installPlugin(source: string): Promise<InstalledPlugin> {
 
     // Use npm to install
     execSync(`npm install "${npmPackage}"`, { cwd: pluginDir, stdio: "inherit" });
+    ensurePluginDependencies(pluginDir, npmPackage);
 
     // Read installed package metadata
     const pkgPath = join(pluginDir, "node_modules", npmPackage, "package.json");


### PR DESCRIPTION
### Motivation
- Several channel and provider plugins audited in WOP-23 were failing to install cleanly due to missing runtime/transitive dependencies, so installs need a targeted backfill to ensure the host app can load them.

### Description
- Added a `PLUGIN_DEPENDENCY_BACKFILL` map in `src/plugins.ts` listing the audited plugins and their required packages (slack, signal, whatsapp, imessage, webui, p2p, provider-anthropic, provider-kimi).
- Implemented `ensurePluginDependencies(pluginRoot, pluginName)` which installs any backfilled dependencies via `npm install` and logs the action.
- Invoked `ensurePluginDependencies` after dependency installation in all plugin install code paths (GitHub repo installs, local path installs, and npm package installs) so missing deps get applied regardless of source.
- All changes are contained in `src/plugins.ts` and keep existing build/packaging behavior (still runs `npm run build` for TypeScript plugins when present).

### Testing
- Ran `npm run build` to verify TypeScript compiles successfully and the change does not break the build (succeeded).
- Queried the npm registry for each backfilled package with a scripted `node -e` check to ensure the packages exist and are resolvable (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d144441c8832f8a2220955229ebc4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins now automatically have their required dependencies installed during setup, ensuring reliable installation and compatibility regardless of source (GitHub, local, or npm registry).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->